### PR TITLE
feat: implement $HOME substitution in presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ preset.
 `peth listp` - lists all saved presets with a visual indication regarding which one is currently loaded.
 
 ### rmp
-`peth rmp <name>` - removes a previously saved named preset.
+`peth rmp <name>` - removes a previously saved named preset (prompts for confirmation).
 
 ## Other Commands
 ### update
@@ -106,7 +106,7 @@ preset.
 `peth help` - displays help.
 
 ## Automatic Preset Loading with `.pethrc`
-When you change directory the plugin looks for a file named `.pethrc` in the target directory. If one is found, it tries to read a preset name from it and load it into the current session. This is helpful if you need different sets of tools or verisons for different projects. To take adventage of this feature, first [save](#save) a named preset and then just create a `.pethrc` with its name in your project directory.
+When you change directory the plugin looks for a file named `.pethrc` in the target directory. If one is found, it tries to read a preset name from it and load it into the current session. This is helpful if you need different sets of tools or verisons for different projects. To take advantage of this feature, first [save](#save) a named preset and then just create a `.pethrc` with its name in your project directory.
 
 ## Zsh Completion
 The plugin comes bundled with completion functions that are automatically registered to be loaded if Zsh completion system is enabled.
@@ -122,7 +122,7 @@ compinit
 1. Clone this repository to a directory of your choice
 ```bash
 cd /your-dir
-git clone git@github.com:sha1n/path-ethics.git
+git clone git@github.com:sha1n/path-ethic.git
 ```
 2. Enable the plugin by sourcing it's main script in `~/.zshrc` .
 ```bash 
@@ -131,7 +131,7 @@ source /your-dir/path-ethic/path-ethic.plugin.zsh
 ## Install as Oh-My-Zsh plugin
 1. Clone this repository to `$ZSH_CUSTOM/plugins/path-ethic`
 ```bash
-mkdir -p "$ZSH_CUSTOM/plugins" && git clone git@github.com:sha1n/path-ethics.git "$ZSH_CUSTOM/plugins/path-ethic"
+mkdir -p "$ZSH_CUSTOM/plugins" && git clone git@github.com:sha1n/path-ethic.git "$ZSH_CUSTOM/plugins/path-ethic"
 ```
 2. Enable the plugin by adding `path-ethic` to the plugin list `plugins=()` in `~/.zshrc` .
 ```bash 

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,7 +96,7 @@ preset.
 `peth listp` - lists all saved presets with a visual indication regarding which one is currently loaded.
 
 ### rmp
-`peth rmp <name>` - removes a previously saved named preset.
+`peth rmp <name>` - removes a previously saved named preset (prompts for confirmation).
 
 ## Other Commands
 ### update
@@ -106,7 +106,7 @@ preset.
 `peth help` - displays help.
 
 ## Automatic Preset Loading with `.pethrc`
-When you change directory the plugin looks for a file named `.pethrc` in the target directory. If one is found, it tries to read a preset name from it and load it into the current session. This is helpful if you need different sets of tools or verisons for different projects. To take adventage of this feature, first [save](#save) a named preset and then just create a `.pethrc` with its name in your project directory.
+When you change directory the plugin looks for a file named `.pethrc` in the target directory. If one is found, it tries to read a preset name from it and load it into the current session. This is helpful if you need different sets of tools or verisons for different projects. To take advantage of this feature, first [save](#save) a named preset and then just create a `.pethrc` with its name in your project directory.
 
 ## Zsh Completion
 The plugin comes bundled with completion functions that are automatically registered to be loaded if Zsh completion system is enabled.
@@ -122,7 +122,7 @@ compinit
 1. Clone this repository to a directory of your choice
 ```bash
 cd /your-dir
-git clone git@github.com:sha1n/path-ethics.git
+git clone git@github.com:sha1n/path-ethic.git
 ```
 2. Enable the plugin by sourcing it's main script in `~/.zshrc` .
 ```bash 
@@ -131,7 +131,7 @@ source /your-dir/path-ethic/path-ethic.plugin.zsh
 ## Install as Oh-My-Zsh plugin
 1. Clone this repository to `$ZSH_CUSTOM/plugins/path-ethic`
 ```bash
-mkdir -p "$ZSH_CUSTOM/plugins" && git clone git@github.com:sha1n/path-ethics.git "$ZSH_CUSTOM/plugins/path-ethic"
+mkdir -p "$ZSH_CUSTOM/plugins" && git clone git@github.com:sha1n/path-ethic.git "$ZSH_CUSTOM/plugins/path-ethic"
 ```
 2. Enable the plugin by adding `path-ethic` to the plugin list `plugins=()` in `~/.zshrc` .
 ```bash 

--- a/peth-presets.zsh
+++ b/peth-presets.zsh
@@ -29,12 +29,12 @@ function __pe_save() {
   local preset_file_name=$(__pe_generate_preset_file_name "$preset_name")
   local preset_path="$PATH_ETHIC_CONFIG/$preset_file_name"
 
-  echo "PATH_ETHIC_HEAD=$PATH_ETHIC_HEAD" >"$preset_path"
-  echo "PATH_ETHIC_TAIL=$PATH_ETHIC_TAIL" >>"$preset_path"
+  echo "PATH_ETHIC_HEAD=${PATH_ETHIC_HEAD//$HOME/\$HOME}" >"$preset_path"
+  echo "PATH_ETHIC_TAIL=${PATH_ETHIC_TAIL//$HOME/\$HOME}" >>"$preset_path"
   
   # We only override the actual PATH in non-default presets
   if [[ "$preset_name" != $PATH_ETHIC_DEFAULT_PRESET_NAME ]]; then 
-    echo "PATH=$PATH" >>"$preset_path"
+    echo "PATH=${PATH//$HOME/\$HOME}" >>"$preset_path"
   fi
 
   PATH_ETHIC_CURRENT_PRESET_NAME="$preset_name"

--- a/peth.zsh
+++ b/peth.zsh
@@ -17,11 +17,11 @@ function __pe_help() {
   peth command [arguments]
 
 
-Available Command: 
+Available Commands: 
 
   show          - shows the effective PATH and your current session settings
   list          - lists all effective PATH elements in the current session
-  push <path>   - pushes an element to the begining of the current session PATH
+  push <path>   - pushes an element to the beginning of the current session PATH
   append <path> - appends an element to the end of the current session PATH
   rm <path>     - finds and removes an element from the session PATH
   flip          - flips the order of your set prefix and suffix in the current 
@@ -32,7 +32,7 @@ Available Command:
                   as a preset under that name
   load [name]   - loads previously saved settings into the current session
                   If a name argument is provided attempts to load a saved preset
-  rmp [name]    - removes a previously saved preset
+  rmp [name]    - removes a previously saved preset (prompts for confirmation)
   listp         - lists all saved presets
   update        - updates the plugin from github
   help          - displays this help message

--- a/tests/home_substitution.test.sh
+++ b/tests/home_substitution.test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env zsh
+
+# setup #######################################################################
+
+source ${0:a:h}/unit.sh
+
+local original_path="$PATH"
+
+# home substitution ###########################################################
+function test_save_with_home_substitution() {
+  before_each
+
+  local home_sub_dir="$HOME/peth_test_dir_$$"
+  mkdir -p "$home_sub_dir"
+
+  peth push "$home_sub_dir"
+  peth save home_preset
+
+  assert_preset_exists "home_preset"
+
+  # Check content of the preset file for $HOME literal
+  local preset_file="$PATH_ETHIC_CONFIG/home_preset.preset"
+  if ! grep -Fq "\$HOME" "$preset_file"; then
+     print "Preset file does not contain \$HOME substitution. Content: $(cat $preset_file)"
+     exit 1
+  fi
+
+  # Clean up and reload
+  peth reset
+  peth load home_preset
+  
+  assert_equal $PATH_ETHIC_HEAD "$home_sub_dir"
+  
+  rm -rf "$home_sub_dir"
+}
+
+#
+# run all tests
+#
+
+test_save_with_home_substitution


### PR DESCRIPTION
- Replaces user home directory with $HOME literal when saving presets to ensure portability.
- Adds regression test tests/home_substitution.test.sh.
