### PR TITLE
fix: remove hardcoded branch in update and fix typos

### DIFF
--- a/peth.zsh
+++ b/peth.zsh
@@ -53,7 +53,7 @@ function __pe_self_update() {
     fi
 
     __pe_log "\nPulling latest changes from remote repository..."
-    if git -C "$PATH_ETHIC_HOME" pull origin master; then
+    if git -C "$PATH_ETHIC_HOME" pull --rebase; then
         __pe_log "Update successful!"
     else
         __pe_log_error "Update failed!"

--- a/tests/plugin.test.sh
+++ b/tests/plugin.test.sh
@@ -7,7 +7,7 @@ source ${0:a:h}/unit.sh
 local original_path="$PATH"
 
 # load_path_ethic #############################################################
-funciton test_load_path_ethic() {
+function test_load_path_ethic() {
   before_each
 
   local default_preset_path="$HOME/.path-ethic/default.preset"
@@ -25,7 +25,7 @@ funciton test_load_path_ethic() {
 }
 
 # __pe_load_pethrc ############################################################
-funciton test_load_pethrc() {
+function test_load_pethrc() {
   before_each
 
   local pethrc_dir=$(mktemp -d)


### PR DESCRIPTION
- Updated __pe_self_update to use 'git pull --rebase' instead of hardcoded master branch.
- Corrected 'funciton' typos in tests/plugin.test.sh.
