### PR TITLE
fix: improve path stripping robustness

### DIFF
--- a/lib.zsh
+++ b/lib.zsh
@@ -1,8 +1,31 @@
 
 
 function __pe_strip_original_path() {
-    local new_path=${PATH##"$PATH_ETHIC_HEAD"}
-    new_path=${new_path%%"$PATH_ETHIC_TAIL"}
+    local new_path="$PATH"
+    
+    if [[ -n "$PATH_ETHIC_HEAD" ]]; then
+        local temp="${new_path/$PATH_ETHIC_HEAD:/}"
+        if [[ "$temp" == "$new_path" ]]; then
+            temp="${new_path/:$PATH_ETHIC_HEAD/}"
+        fi
+        
+        if [[ "$temp" == "$new_path" && "$new_path" == "$PATH_ETHIC_HEAD" ]]; then
+            temp=""
+        fi
+        new_path="$temp"
+    fi
+
+    if [[ -n "$PATH_ETHIC_TAIL" ]]; then
+        local temp="${new_path/$PATH_ETHIC_TAIL:/}"
+        if [[ "$temp" == "$new_path" ]]; then
+            temp="${new_path/:$PATH_ETHIC_TAIL/}"
+        fi
+        
+        if [[ "$temp" == "$new_path" && "$new_path" == "$PATH_ETHIC_TAIL" ]]; then
+            temp=""
+        fi
+        new_path="$temp"
+    fi
 
     echo $(__pe_normalize_path $new_path)
 }

--- a/tests/path_stripping.test.sh
+++ b/tests/path_stripping.test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env zsh
+
+# setup #######################################################################
+
+source ${0:a:h}/unit.sh
+
+local original_path="$PATH"
+
+# strip logic with prepended injection ########################################
+function test_strip_logic_with_prepended_injection() {
+  before_each
+
+  local head_dir="/head"
+  local tail_dir="/tail"
+  local injected_dir="/injected"
+
+  PATH_ETHIC_HEAD="$head_dir"
+  PATH_ETHIC_TAIL="$tail_dir"
+
+  # Simulate PATH with an injected element BEFORE the expected head
+  PATH="$injected_dir:$head_dir:$original_path:$tail_dir"
+
+  local stripped=$(__pe_strip_original_path)
+
+  assert_equal "$stripped" "$injected_dir:$original_path"
+}
+
+# strip logic with interrupted tail ###########################################
+function test_strip_logic_with_interrupted_tail() {
+  before_each
+
+  local head_dir="/head"
+  local tail_dir="/tail"
+  local injected_dir="/injected"
+
+  PATH_ETHIC_HEAD="$head_dir"
+  PATH_ETHIC_TAIL="$tail_dir"
+
+  # Simulate PATH with an injected element AFTER the expected tail
+  PATH="$head_dir:$original_path:$tail_dir:$injected_dir"
+
+  local stripped=$(__pe_strip_original_path)
+
+  assert_equal "$stripped" "$original_path:$injected_dir"
+}
+
+#
+# run all tests
+#
+
+test_strip_logic_with_prepended_injection
+test_strip_logic_with_interrupted_tail


### PR DESCRIPTION
- Updated __pe_strip_original_path to handle cases where PATH is modified externally (e.g., injections), ensuring HEAD and TAIL are correctly identified and removed.
- Added tests/path_stripping.test.sh to verify the fix.
