### PR TITLE
build: upgrade zsh-scriptest to v2

### DIFF
--- a/tests/path_edit_commands.test.sh
+++ b/tests/path_edit_commands.test.sh
@@ -104,8 +104,10 @@ function test_peth_rm() {
 # run all tests
 #
 
-test_path_list
-test_peth_reset
-test_peth_push
-test_peth_append
-test_peth_flip
+run_test test_path_list
+run_test test_peth_reset
+run_test test_peth_push
+run_test test_peth_append
+run_test test_peth_flip
+run_test test_peth_rm
+finish_tests

--- a/tests/plugin.test.sh
+++ b/tests/plugin.test.sh
@@ -55,6 +55,7 @@ funciton test_load_pethrc() {
 # run all tests
 #
 
-test_load_path_ethic
-test_load_pethrc
+run_test test_load_path_ethic
+run_test test_load_pethrc
+finish_tests
 

--- a/tests/preset_commands.test.sh
+++ b/tests/preset_commands.test.sh
@@ -182,12 +182,13 @@ function test_rmp_existing_unloaded() {
 # run all tests
 #
 
-test_peth_load
-test_peth_save_empty
-test_peth_save_nonempty
-test_peth_save_named_with_path_override
-test_peth_save_default_with_path_override
-test_save_load_preset
-test_rmp_nonexisting
-test_rmp_loaded
-test_rmp_existing_unloaded
+run_test test_peth_load
+run_test test_peth_save_empty
+run_test test_peth_save_nonempty
+run_test test_peth_save_named_with_path_override
+run_test test_peth_save_default_with_path_override
+run_test test_save_load_preset
+run_test test_rmp_nonexisting
+run_test test_rmp_loaded
+run_test test_rmp_existing_unloaded
+finish_tests


### PR DESCRIPTION
## Summary
- Bump `zsh-scriptest` submodule to v2
- Migrate all test files to the v2 API (`run_test` / `finish_tests`)

## Test plan
- [x] Run test suites to verify they pass with the updated framework

🤖 Generated with [Claude Code](https://claude.com/claude-code)